### PR TITLE
Add navigator.clipboard copy option

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.copy-post-plugin",
     "name": "Copy Post",
     "description": "Allow to copy posts content",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "webapp": {
         "bundle_path": "webapp/dist/main.js"
     }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'com.mattermost.copy-post-plugin';
-export const version = '0.0.1';
+export const version = '0.0.2';

--- a/webapp/src/plugin.jsx
+++ b/webapp/src/plugin.jsx
@@ -4,17 +4,31 @@ import {getPost} from 'mattermost-redux/selectors/entities/posts';
 
 import {id as pluginId} from './manifest';
 
-export default class DemoPlugin {
+export default class CopyPlugin {
     initialize(registry, store) {
         registry.registerPostDropdownMenuAction(<span className='copy-plugin-button'>{'Copy'}</span>, (postId) => {
-            const _ = new ClipboardJS('.copy-plugin-button', {
-                text: () => {
-                    const state = store.getState();
-                    const post = getPost(state, postId);
-                    return post && post.message;
-                },
-            });
-            document.getElementsByClassName('copy-plugin-button')[0].click();
+            const state = store.getState();
+            const post = getPost(state, postId);
+
+            // Try using navigator.clipboard for better error handling and
+            // insurance that the clipboard was updated. Fall back to original
+            // copy method if that isn't supported.
+            // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
+            var clipboard = navigator.clipboard;
+            if (clipboard != undefined) {
+                clipboard.writeText(post.message).then(() => {
+                        // Success!
+                    }).catch(err => {
+                        console.error('Unable to copy to clipboard', err);
+                    });
+            } else {
+                const _ = new ClipboardJS('.copy-plugin-button', {
+                    text: () => { 
+                        return post && post.message;
+                    },
+                });
+                document.getElementsByClassName('copy-plugin-button')[0].click();
+            }
         });
     }
 


### PR DESCRIPTION
This new behavior tries to use a new web API for interacting with
the client's clipboard. If this new library is not available then
the old method is fallen back on.

Reasoning for this improvement can be found here:
https://mattermost.atlassian.net/browse/MM-17296